### PR TITLE
Correção da função raiz (resolve #196)

### DIFF
--- a/fontes/bibliotecas/biblioteca-global.ts
+++ b/fontes/bibliotecas/biblioteca-global.ts
@@ -70,7 +70,8 @@ export async function raiz(
     indice = 2
 ) {
     const valor = typeof interpretadorOuValor === 'number' ? interpretadorOuValor : valorOuIndice;
-    const indiceEfetivo = typeof interpretadorOuValor === 'number' ? valorOuIndice : indice;
+    const indiceEfetivoBruto = typeof interpretadorOuValor === 'number' ? valorOuIndice : indice;
+    const indiceEfetivo = indiceEfetivoBruto ?? 2;
     return Promise.resolve(Math.pow(valor, 1 / indiceEfetivo));
 }
 

--- a/testes/interpretador.test.ts
+++ b/testes/interpretador.test.ts
@@ -927,6 +927,19 @@ describe('Interpretador (Potigol)', () => {
                 expect(Number(_saidas[1])).toBeCloseTo(3, 10);
             });
 
+            it('raiz sem indice deve assumir raiz quadrada', async () => {
+                const retornoLexador = lexador.mapear([
+                    'escreva(raiz(4))'
+                ], -1);
+
+                const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                expect(retornoInterpretador.erros).toHaveLength(0);
+                expect(_saidas).toHaveLength(1);
+                expect(_saidas[0]).toBe('2');
+            });
+            
             describe('Primitivas de Texto', () => {
                 it('formato, número com casas decimais', async () => {
                     const saidas: string[] = [];


### PR DESCRIPTION
Correção da função `raiz` quando o segundo parâmetro for null.